### PR TITLE
Add internal links to top-traffic blog posts

### DIFF
--- a/posts/2025-09-15-p50-vs-p95-vs-p99-latency-percentiles/README.md
+++ b/posts/2025-09-15-p50-vs-p95-vs-p99-latency-percentiles/README.md
@@ -220,7 +220,7 @@ More on SLOs & budgets: https://oneuptime.com/blog/post/2023-06-12-sli-sla-slo/v
 
 ## Tooling Tips
 
-- Use one platform (e.g. OneUptime) so traces, metrics, logs, and SLO burn are correlated.
+- Use one platform so traces, metrics, logs, and SLO burn are correlated. [OneUptime's APM and distributed tracing](https://oneuptime.com/product/apm) can help you track P50/P95/P99 percentiles across your services and correlate slow traces with infrastructure metrics.
 - Store latency as a histogram, not a counter of rolled-up percentiles.
 - Tag latency metrics with stable dimensions only (method, route template, status_code, region). Avoid user-specific labels.
 - Track request volume alongside percentiles- P99 with 20 requests means little.

--- a/posts/2026-01-07-ubuntu-ufw-firewall/README.md
+++ b/posts/2026-01-07-ubuntu-ufw-firewall/README.md
@@ -518,6 +518,8 @@ sudo grep "BLOCK" /var/log/ufw.log
 sudo grep "SRC=192.168.1.100" /var/log/ufw.log
 ```
 
+For production servers, consider forwarding firewall logs to a centralized monitoring platform. [OneUptime's log management](https://oneuptime.com/product/logs) can aggregate logs from multiple servers, making it easier to spot attack patterns, correlate blocked IPs across your infrastructure, and set up alerts for suspicious activity.
+
 ### Disabling Logging
 
 Turn off logging if not needed:

--- a/posts/2026-01-16-docker-limit-cpu-memory/README.md
+++ b/posts/2026-01-16-docker-limit-cpu-memory/README.md
@@ -202,6 +202,8 @@ CONTAINER ID   NAME      CPU %     MEM USAGE / LIMIT   MEM %     NET I/O        
 a1b2c3d4e5f6   my-app    45.32%    234.5MiB / 512MiB   45.80%    1.23MB / 456kB   12.3MB / 0B
 ```
 
+While `docker stats` is useful for quick checks, production environments benefit from continuous monitoring. Tools like [OneUptime](https://oneuptime.com/product/metrics) can collect container metrics over time, helping you identify memory leaks, CPU throttling patterns, and set up alerts before containers hit their limits and get OOM-killed.
+
 ## Recommended Limits by Workload Type
 
 | Workload Type | Memory | CPU | Notes |

--- a/posts/2026-01-24-websocket-connection-closed-abnormally/README.md
+++ b/posts/2026-01-24-websocket-connection-closed-abnormally/README.md
@@ -634,3 +634,5 @@ ws.onclose = (event) => {
 | Server restart | Implement graceful shutdown with close frames |
 
 The key to handling abnormal closures is detecting them quickly through heartbeats and recovering gracefully through automatic reconnection with exponential backoff. Always send close frames when intentionally closing connections to help distinguish between intentional and unintentional disconnections.
+
+For production WebSocket services, consider setting up monitoring to track connection metrics and error rates. [OneUptime](https://oneuptime.com/product/apm) can help you monitor WebSocket server health, track error rates by close code, and alert you when abnormal closures spike—often a leading indicator of infrastructure issues.

--- a/posts/2026-01-30-self-hosted-llm-with-moltbot/README.md
+++ b/posts/2026-01-30-self-hosted-llm-with-moltbot/README.md
@@ -305,6 +305,8 @@ flowchart LR
 
 ## Performance Optimization Tips
 
+Running LLMs in production requires monitoring to ensure they're performing well. If you're self-hosting at scale, consider setting up observability for your inference servers—tools like [OneUptime](https://oneuptime.com/product/metrics) can track GPU utilization, inference latency, and alert you when models are underperforming or containers crash.
+
 ### 1. Use Appropriate Quantization
 
 Ollama uses Q4_K_M by default, which offers a good balance. For better quality with more VRAM:


### PR DESCRIPTION
## Summary

Adds subtle, contextual internal links to OneUptime product pages in 5 high-traffic blog posts (based on GSC data).

## Changes

| Post | Traffic | Link Added |
|------|---------|------------|
| p50-vs-p95-vs-p99-latency | 451 clicks | APM/Traces - percentile tracking |
| self-hosted-llm-with-moltbot | 405 clicks | Metrics - LLM infrastructure monitoring |
| websocket-connection-closed | 213 clicks | APM - connection error monitoring |
| docker-limit-cpu-memory | 185 clicks | Metrics - container monitoring |
| ubuntu-ufw-firewall | 201 clicks | Logs - centralized security logging |

## Skipped Posts (not relevant to monitoring)
- setup-steam-proton-gaming (203 clicks)
- configure-mdns-avahi-ubuntu (201 clicks)
- setup-socks5-proxy-ubuntu (175 clicks)

## Notes
- All links are contextually relevant and add value
- Max 1-2 links per post
- Helpful, not promotional tone
- Links point to specific product pages, not just homepage