### PR TITLE
Fix Traefik v3 tutorial (enable ping and RBAC for serverstransporttcps)

### DIFF
--- a/posts/2026-01-25-traefik-kubernetes-ingress/README.md
+++ b/posts/2026-01-25-traefik-kubernetes-ingress/README.md
@@ -109,6 +109,7 @@ rules:
       - tlsoptions
       - tlsstores
       - serverstransports
+      - serverstransporttcps
     verbs:
       - get
       - list
@@ -184,6 +185,7 @@ spec:
             - --api.insecure=true
             # Log level for debugging
             - --log.level=INFO
+            - --ping=true
           ports:
             - name: web
               containerPort: 80


### PR DESCRIPTION
The current tutorial does not work with Traefik v3. Two corrections are needed:
- Enable the ping flag so that liveness and readiness probes can succeed.
- Update RBAC ClusterRole to include serverstransporttcps in the traefik.io API group. Without this, Traefik logs “forbidden” errors and IngressRoutes return 404.

These changes ensure Traefik v3 Pods become Ready and can load IngressRoute CRDs correctly.
