### PR TITLE
Clarify GitLab Observability tier and self-managed setup prerequisites (#146)

### DIFF
--- a/posts/2026-02-06-instrument-gitlab-ci-opentelemetry/README.md
+++ b/posts/2026-02-06-instrument-gitlab-ci-opentelemetry/README.md
@@ -16,6 +16,14 @@ This guide walks through enabling GitLab's automatic CI/CD telemetry support, ad
 
 GitLab Observability has experimental support for automatic CI/CD pipeline telemetry. When enabled, GitLab captures pipeline execution data after pipelines complete, converts it to OpenTelemetry format, and makes it available in GitLab Observability.
 
+### Tier and Availability (Read This First)
+
+There is a lot of confusion about which GitLab edition you need, so let us be precise. As of GitLab 18.1, the GitLab documentation lists CI/CD pipeline telemetry and GitLab Observability with `Tier: Free, Premium, Ultimate` and `Offering: GitLab.com, GitLab Self-Managed`, and both carry `Status: Experiment`. In other words, the current feature is not gated behind the Ultimate tier.
+
+If you read older documentation (GitLab 16.x and 17.x), you likely saw that observability and distributed tracing required the Ultimate tier and an `observability_features` feature flag. That earlier implementation was reworked. The version covered in this guide (GitLab 18.1 and later) is the one documented for all tiers. Always check the tier badge at the top of the page you are reading, because an experiment can change tier or behavior between releases.
+
+Because this is an experiment, treat it as subject to change and verify the current state against the official docs at https://docs.gitlab.com/operations/observability/ci_cd/ before relying on it in production.
+
 ```mermaid
 graph LR
     A[GitLab Runner] --> B[Pipeline Execution]
@@ -36,9 +44,39 @@ graph LR
 
 The trace hierarchy maps naturally to GitLab's pipeline structure. The pipeline is the root operation, with telemetry for job dependencies, timing, and execution flow.
 
+## Prerequisite: Set Up GitLab Observability First
+
+The `GITLAB_OBSERVABILITY_EXPORT` variable exports telemetry to GitLab Observability, not to an arbitrary OTLP endpoint. So before the CI/CD variable does anything, GitLab Observability has to exist and be connected to your project's group. How you do that depends on where GitLab runs, and this is the step most people miss.
+
+On GitLab.com, there is no `gitlab.rb` to edit and no separate backend to host. You enable it per group in the UI. With the Developer, Maintainer, or Owner role on the group, open the group, go to Settings, then Observability, then Setup, and select Enable Observability. GitLab then generates and displays the OpenTelemetry endpoint URL for that group. See https://docs.gitlab.com/operations/observability/setup_gitlab_com/ for the current steps.
+
+On GitLab Self-Managed, you do not enable this purely by editing `gitlab.rb` either. The current model (GitLab 18.1 and later) runs GitLab Observability as a separate application that you deploy alongside GitLab, then connect to. At a high level the documented steps are:
+
+- Provision a separate host for the Observability backend (the docs reference a `t3.large` or larger virtual machine, at least 100 GB of storage, and Docker plus Docker Compose).
+- Deploy the GitLab Observability backend on that host and open the required ports (for example, 4317 and 4318 for OTLP).
+- Connect your GitLab instance to it by configuring the group's Observability settings.
+
+The group connection is configured through the GitLab Rails console, not through `gitlab.rb`. The documented object is `Observability::GroupO11ySetting`:
+
+```ruby
+# Run on your GitLab Self-Managed instance:
+#   gitlab-rails console
+# Replace the placeholder values with your deployed Observability backend details.
+group = Group.find_by_path('your-group-name')
+Observability::GroupO11ySetting.create!(
+  group_id: group.id,
+  o11y_service_url: 'https://your-o11y-instance.example.com',
+  o11y_service_user_email: 'observability@example.com',
+  o11y_service_password: 'your-secure-password',
+  o11y_service_post_message_encryption_key: 'your-32-char-minimum-encryption-key'
+)
+```
+
+So to answer the two questions that come up most often: this is not an Ultimate-only feature in current GitLab (the docs list Free, Premium, and Ultimate), and on Self-Managed you do not flip it on by editing `gitlab.rb`. You stand up the separate Observability backend and connect the group to it. For the authoritative, version-specific steps, follow https://docs.gitlab.com/operations/observability/setup_self_managed/.
+
 ## Enabling OpenTelemetry in GitLab
 
-To enable automatic pipeline telemetry in GitLab Observability, add the `GITLAB_OBSERVABILITY_EXPORT` CI/CD variable at the project or group level.
+Once GitLab Observability is set up and connected to your group, enable automatic pipeline telemetry by adding the `GITLAB_OBSERVABILITY_EXPORT` CI/CD variable at the project or group level.
 
 For GitLab.com or self-managed projects, set this as a CI/CD variable in your project or group settings under Settings, then CI/CD, then Variables.
 
@@ -52,7 +90,7 @@ For GitLab.com or self-managed projects, set this as a CI/CD variable in your pr
 # GITLAB_OBSERVABILITY_EXPORT: traces,metrics,logs
 ```
 
-Once this variable is set, GitLab automatically captures pipeline execution data after each pipeline completes and exports the selected telemetry types to your GitLab Observability instance.
+Once this variable is set, GitLab automatically captures pipeline execution data after each pipeline completes and exports the selected telemetry types to your connected GitLab Observability instance. If you set the variable but see no data, the most common cause is that GitLab Observability has not been set up and connected for the group, as described in the prerequisite section above.
 
 ## Understanding the Automatic Trace Structure
 

--- a/posts/2026-02-06-instrument-gitlab-ci-opentelemetry/validation-summary.md
+++ b/posts/2026-02-06-instrument-gitlab-ci-opentelemetry/validation-summary.md
@@ -42,3 +42,23 @@ Tutorial / Guide
 - All fenced YAML snippets parse successfully with PyYAML.
 - Ruby was not installed in the review environment, so YAML validation was performed with PyYAML instead of Ruby.
 - The custom span helper intentionally remains a lightweight OTLP/JSON example. Production use should handle JSON escaping for arbitrary step names and should prefer an OpenTelemetry SDK or a maintained CI tracing tool where practical.
+
+## Re-review 2026-06-25 (issue #146)
+
+A reader (issue #146) followed the post but could not get the "project-level configuration" working, and asked two specific questions: (1) is this feature Ultimate-tier only, as some other GitLab docs seemed to imply, and (2) is editing `gitlab.rb` mandatory to get project-level functionality? Re-verified against current official GitLab documentation and made targeted, body-only edits to address the confusion.
+
+### Facts verified (official sources)
+- CI/CD pipeline telemetry for GitLab Observability is documented as `Tier: Free, Premium, Ultimate`, `Offering: GitLab.com, GitLab Self-Managed`, `Status: Experiment`. It is NOT Ultimate-only in the current (GitLab 18.1+) docs. Source: https://docs.gitlab.com/operations/observability/ci_cd/
+- GitLab Observability itself carries the same tier badge (`Free, Premium, Ultimate`) and `Status: Experiment`, and is described as available for all tiers. Source: https://docs.gitlab.com/operations/observability/observability/
+- The reporter's "Ultimate-only" impression matches the older (GitLab 16.x/17.x) implementation, where observability/distributed tracing required Ultimate and the `observability_features` feature flag (flags introduced around 16.2, beta in 17.x). That earlier model was reworked. Sources: https://docs.gitlab.com/operations/observability/observability/ and the GitLab feature-flag history (`observability_features`, formerly `observability_tracing`).
+- On GitLab.com, GitLab Observability is enabled per group in the UI (Settings > Observability > Setup > Enable Observability) by a user with Developer/Maintainer/Owner role; no `gitlab.rb` edit. Source: https://docs.gitlab.com/operations/observability/setup_gitlab_com/
+- On GitLab Self-Managed (18.1+), GitLab Observability runs as a separate deployed backend (Docker/Docker Compose host, OTLP ports 4317/4318) and is connected to a group via the Rails console object `Observability::GroupO11ySetting` (fields: `group_id`, `o11y_service_url`, `o11y_service_user_email`, `o11y_service_password`, `o11y_service_post_message_encryption_key`). It is NOT enabled by editing `gitlab.rb`. Source: https://docs.gitlab.com/operations/observability/setup_self_managed/
+
+### Changes made to README.md
+- Added an H3 "Tier and Availability (Read This First)" under "GitLab's Built-in OpenTelemetry Support" stating the current Free/Premium/Ultimate tier and Experiment status, and explaining that the Ultimate-only impression comes from the older 16.x/17.x implementation that has since been reworked.
+- Added a new H2 "Prerequisite: Set Up GitLab Observability First" that explains the export targets GitLab Observability (not an arbitrary OTLP endpoint), documents the GitLab.com UI enablement path, documents the Self-Managed path (separate backend plus `Observability::GroupO11ySetting` via Rails console), and explicitly answers the two reader questions (not Ultimate-only; `gitlab.rb` editing is not how you enable it).
+- Updated the "Enabling OpenTelemetry in GitLab" section so it now depends on the prerequisite and adds a troubleshooting note that missing data usually means Observability is not set up/connected for the group.
+
+### Notes / caveats
+- The feature remains an Experiment, so tier, feature flags, and setup steps can change between releases. The post now points readers to the official docs to re-verify.
+- Self-managed setup specifics (instance sizing, ports, exact Rails fields) are summarized from the official setup page and may evolve; the post links to that page for the authoritative steps.

--- a/posts/2026-02-06-instrument-gitlab-ci-opentelemetry/validation.json
+++ b/posts/2026-02-06-instrument-gitlab-ci-opentelemetry/validation.json
@@ -1,4 +1,4 @@
 {
     "status": "validated",
-    "validatedAt": "2026-06-05"
+    "validatedAt": "2026-06-25"
 }


### PR DESCRIPTION
Resolves a reader's confusion (#146) about the GitLab CI OpenTelemetry post.

Current GitLab docs (18.1+) list CI/CD pipeline telemetry and GitLab Observability as Free/Premium/Ultimate with Experiment status, so the feature is **not** Ultimate-only. The older 16.x/17.x implementation that required Ultimate and the `observability_features` (formerly `observability_tracing`) flag was reworked, which is the source of the "Ultimate only" impression.

Changes:
- Added a "Tier and Availability" note stating the current tier/status and explaining the historical Ultimate-only confusion.
- Added a "Prerequisite: Set Up GitLab Observability First" section covering the GitLab.com UI enablement path and the self-managed backend + Rails console (`Observability::GroupO11ySetting`) path, clarifying that you do not enable it by editing `gitlab.rb`.
- Made the enablement step depend on that prerequisite and added a "no data" troubleshooting note.

Sources: https://docs.gitlab.com/operations/observability/ci_cd/ , https://docs.gitlab.com/operations/observability/observability/ , https://docs.gitlab.com/operations/observability/setup_gitlab_com/ , https://docs.gitlab.com/operations/observability/setup_self_managed/

`npm run validate` passes.

Resolves #146
