### PR TITLE
Document reverse_tunnel_key creation for the SSH reverse tunnel post (#139)

### DIFF
--- a/posts/2026-03-20-ssh-reverse-tunnel-nat-ipv4/README.md
+++ b/posts/2026-03-20-ssh-reverse-tunnel-nat-ipv4/README.md
@@ -58,6 +58,103 @@ From any machine after binding the tunnel to the public address as shown in the 
 ssh -p 2222 private-user@203.0.113.10
 ```
 
+## Creating the Tunnel Key
+
+The systemd service below authenticates with a dedicated SSH key at `/home/tunnel-user/.ssh/reverse_tunnel_key`. That file does not exist yet, so create it before enabling the service. A dedicated key keeps the tunnel's credentials separate from any human login key and lets you lock the key down to reverse-forwarding only.
+
+### 1. Generate the keypair
+
+Run this on the private host as `root` (or with `sudo`), then hand ownership back to `tunnel-user`:
+
+```bash
+# Create the .ssh directory for the local tunnel-user if it does not exist
+sudo -u tunnel-user mkdir -p /home/tunnel-user/.ssh
+
+# Generate a dedicated ed25519 keypair with no passphrase
+# (no passphrase is required because the service starts unattended)
+sudo -u tunnel-user ssh-keygen -t ed25519 \
+  -f /home/tunnel-user/.ssh/reverse_tunnel_key \
+  -N "" \
+  -C "reverse-tunnel@private-host"
+```
+
+This writes the private key to `/home/tunnel-user/.ssh/reverse_tunnel_key` and the public key to `/home/tunnel-user/.ssh/reverse_tunnel_key.pub`.
+
+### 2. Fix ownership and permissions
+
+OpenSSH refuses to use a private key or an `authorized_keys` file that is readable or writable by other users. Confirm the directory and key have the correct ownership and modes:
+
+```bash
+# Everything under .ssh must be owned by tunnel-user
+sudo chown -R tunnel-user:tunnel-user /home/tunnel-user/.ssh
+
+# .ssh directory: read/write/execute for owner only
+sudo chmod 700 /home/tunnel-user/.ssh
+
+# Private key: read/write for owner only
+sudo chmod 600 /home/tunnel-user/.ssh/reverse_tunnel_key
+
+# Public key may be world-readable
+sudo chmod 644 /home/tunnel-user/.ssh/reverse_tunnel_key.pub
+```
+
+`ssh-keygen` already creates the private key with mode `600`, but setting it explicitly avoids surprises if the file was copied around.
+
+### 3. Install the public key on the public server
+
+The reverse forward authenticates as `tunnel@203.0.113.10`, so the public key must be added to that remote account's `~/.ssh/authorized_keys`. Print the public key on the private host:
+
+```bash
+sudo cat /home/tunnel-user/.ssh/reverse_tunnel_key.pub
+```
+
+If the remote `tunnel` account currently allows password login, you can push the key with `ssh-copy-id`:
+
+```bash
+# Run on the private host; -i points at the matching public key
+sudo -u tunnel-user ssh-copy-id \
+  -i /home/tunnel-user/.ssh/reverse_tunnel_key.pub \
+  tunnel@203.0.113.10
+```
+
+Otherwise, log in to the public server through another route and append the line manually. Restrict the key to reverse forwarding only by prefixing it with `authorized_keys` options. The `restrict` option disables everything (PTY, agent, X11, and port forwarding), then `port-forwarding` re-enables forwarding and `permitlisten` limits it to the single tunnel port:
+
+```text
+# /home/tunnel/.ssh/authorized_keys on the public server (203.0.113.10)
+# Paste the contents of reverse_tunnel_key.pub after the options, on one line.
+
+restrict,port-forwarding,permitlisten="127.0.0.1:2222",command="/usr/sbin/nologin" ssh-ed25519 AAAA...reverse-tunnel@private-host
+```
+
+These options pair with the server-side `Match User tunnel` block in the hardening section: even if that block were missing, the key itself could only open the reverse forward on port 2222 and could not get a shell. Make sure the remote `~/.ssh` is mode `700` and `authorized_keys` is mode `600`, both owned by `tunnel`.
+
+### 4. Pre-seed the public server's host key
+
+The service runs with `StrictHostKeyChecking=yes`, which means the connection fails if the public server's host key is not already trusted by `tunnel-user`. Because the service runs unattended as `tunnel-user`, there is no interactive prompt to accept the key the first time. Seed it ahead of time.
+
+The safest option is one interactive connection so you can verify and accept the fingerprint:
+
+```bash
+# Connect once as tunnel-user; accept the host key after verifying the fingerprint
+sudo -u tunnel-user ssh \
+  -i /home/tunnel-user/.ssh/reverse_tunnel_key \
+  tunnel@203.0.113.10
+```
+
+That records the host key in `/home/tunnel-user/.ssh/known_hosts`. The login itself will be closed immediately by the `command="/usr/sbin/nologin"` restriction, which is expected; the goal is only to record the host key.
+
+If you have verified the public server's host key fingerprint through a trusted channel and prefer a non-interactive step, use `ssh-keyscan` instead:
+
+```bash
+# Append the public server's host key to tunnel-user's known_hosts
+sudo -u tunnel-user sh -c \
+  'ssh-keyscan -H 203.0.113.10 >> /home/tunnel-user/.ssh/known_hosts'
+```
+
+Only trust a `ssh-keyscan` result after confirming the fingerprint out of band; otherwise you are exposed to a man-in-the-middle on first connect.
+
+With the key generated, permissioned, authorized on the remote account, and the host key trusted, the service below can start cleanly.
+
 ## Persistent Reverse Tunnel with autossh
 
 On the private host, create a systemd service:

--- a/posts/2026-03-20-ssh-reverse-tunnel-nat-ipv4/validation-summary.md
+++ b/posts/2026-03-20-ssh-reverse-tunnel-nat-ipv4/validation-summary.md
@@ -49,3 +49,23 @@ Tutorial
 - The example address `203.0.113.10` is in TEST-NET-3, which is reserved for documentation and should be replaced with a real public server address in actual deployments.
 - `NoHostAuthenticationForLocalhost yes` is syntactically valid, but it disables host authentication for the loopback connection. A future improvement would be to show a `HostKeyAlias`-based approach for preserving host-key checks through the tunnel.
 - The `iptables` rule is technically valid, but it may not persist across reboot and may not match systems using nftables, firewalld, or ufw as the primary firewall frontend.
+
+## Re-review 2026-06-25 (issue #139)
+
+Issue #139 reported that the autossh systemd unit references `/home/tunnel-user/.ssh/reverse_tunnel_key` without explaining how to create it, leaving less-experienced readers stuck.
+
+### Added
+- New `## Creating the Tunnel Key` section placed immediately before `## Persistent Reverse Tunnel with autossh` (where the key is first used), with four sub-steps:
+  1. Generate a dedicated keypair matching the post's path/user: `ssh-keygen -t ed25519 -f /home/tunnel-user/.ssh/reverse_tunnel_key -N ""`.
+  2. Set ownership (`tunnel-user:tunnel-user`) and permissions (`.ssh` 700, private key 600, public key 644).
+  3. Install the public key into the remote `tunnel@203.0.113.10` account's `authorized_keys` via `ssh-copy-id` or manual append, with restrictive options `restrict,port-forwarding,permitlisten="127.0.0.1:2222",command="/usr/sbin/nologin"` (matching the post's reverse port 2222 and existing `nologin` hardening).
+  4. Pre-seed the public server's host key into `tunnel-user`'s `known_hosts` (one interactive `ssh` connection, or `ssh-keyscan -H` after out-of-band fingerprint verification) so `StrictHostKeyChecking=yes` succeeds when the unattended service starts.
+
+### Facts verified
+- `ssh-keygen -t ed25519 -f <file> -N ""` generates an ed25519 key with no passphrase; private key is created mode 600 by default. Source: https://man.openbsd.org/ssh-keygen.1
+- OpenSSH requires `~/.ssh` not writable by others (700 recommended) and `authorized_keys` not accessible by others (600 recommended), or sshd refuses the key under StrictModes. Source: https://man.openbsd.org/sshd.8
+- `restrict` disables PTY/agent/X11/port-forwarding; adding `port-forwarding` re-enables forwarding and `permitlisten` limits the reverse listener. Source: https://man.openbsd.org/sshd.8
+- `ssh-keyscan -H host >> known_hosts` records a host key but must be verified out of band to avoid MITM. Source: https://man.openbsd.org/ssh-keyscan.1
+
+### Format
+- Body-only edit; title, Tags, and Description lines untouched. All new fenced blocks declare a language (`bash` for shell, `text` for the authorized_keys snippet). No em dashes, no smart quotes, single H1.

--- a/posts/2026-03-20-ssh-reverse-tunnel-nat-ipv4/validation.json
+++ b/posts/2026-03-20-ssh-reverse-tunnel-nat-ipv4/validation.json
@@ -1,4 +1,4 @@
 {
     "status": "validated",
-    "validatedAt": "2026-04-21"
+    "validatedAt": "2026-06-25"
 }


### PR DESCRIPTION
The SSH reverse tunnel post referenced `/home/tunnel-user/.ssh/reverse_tunnel_key` in the autossh systemd unit but never explained how to create it (#139).

This adds a "Creating the Tunnel Key" section before the systemd unit, walking less-experienced readers through:
- Generating a dedicated ed25519 keypair at the exact path the unit expects: `ssh-keygen -t ed25519 -f /home/tunnel-user/.ssh/reverse_tunnel_key -N ""`.
- Setting correct ownership and permissions (`.ssh` 700, private key 600).
- Installing the public key into the remote `tunnel@203.0.113.10` account's `authorized_keys` with reverse-forwarding-only restrictions (`restrict,port-forwarding,permitlisten="127.0.0.1:2222"`).
- Pre-seeding the server's host key into `known_hosts` so the unattended service works with `StrictHostKeyChecking=yes`.

All commands and paths match names already used in the post. Verified against the OpenSSH man pages for ssh-keygen, sshd, and ssh-keyscan. `npm run validate` passes.

Resolves #139
