### PR TITLE
Fix MySQL SKIP LOCKED queue concurrency

### DIFF
--- a/posts/2026-03-31-mysql-skip-locked-and-nowait-mysql-8/README.md
+++ b/posts/2026-03-31-mysql-skip-locked-and-nowait-mysql-8/README.md
@@ -41,12 +41,22 @@ This is useful when you want to retry with a different row or a different strate
 ```sql
 -- Transaction 1 locks job #1
 START TRANSACTION;
-SELECT * FROM jobs WHERE status = 'pending' LIMIT 1 FOR UPDATE;
+SELECT *
+FROM jobs FORCE INDEX (idx_jobs_claim)
+WHERE status = 'pending'
+ORDER BY created_at, id
+LIMIT 1
+FOR UPDATE;
 -- Returns job #1, holds lock
 
 -- Transaction 2 - skips job #1 and picks the next available job
 START TRANSACTION;
-SELECT * FROM jobs WHERE status = 'pending' LIMIT 1 FOR UPDATE SKIP LOCKED;
+SELECT *
+FROM jobs FORCE INDEX (idx_jobs_claim)
+WHERE status = 'pending'
+ORDER BY created_at, id
+LIMIT 1
+FOR UPDATE SKIP LOCKED;
 -- Returns job #2 (skips locked job #1)
 ```
 
@@ -60,7 +70,7 @@ CREATE TABLE jobs (
     payload JSON NOT NULL,
     status ENUM('pending', 'processing', 'done', 'failed') DEFAULT 'pending',
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-    INDEX idx_status (status)
+    INDEX idx_jobs_claim (status, created_at, id)
 );
 
 INSERT INTO jobs (payload, status) VALUES
@@ -68,6 +78,34 @@ INSERT INTO jobs (payload, status) VALUES
     ('{"task": "send_email", "to": "user2@example.com"}', 'pending'),
     ('{"task": "resize_image", "file": "photo.jpg"}', 'pending');
 ```
+
+The index order is part of the concurrency design. An InnoDB locking read [generally locks every index record it scans](https://dev.mysql.com/doc/refman/8.0/en/innodb-locks-set.html). An index on `status` alone can find pending jobs, but it cannot return them in `created_at` order. The locking scan feeding the filesort must [read all pending matches before it can return `LIMIT 1`](https://dev.mysql.com/doc/refman/8.0/en/limit-optimization.html), allowing one worker to lock every candidate and leaving other workers nothing to claim.
+
+When the plan uses `idx_jobs_claim`, MySQL can read pending jobs in claim order and stop after the first unlocked row. The `id` column provides deterministic ordering when multiple jobs have the same timestamp. Because `status` is the leftmost column, the composite index can also serve queries that filter only by status.
+
+Defining the index does not guarantee that the optimizer will select it, especially when most rows have the same status. The claim queries use `FORCE INDEX (idx_jobs_claim)` so this concurrency-sensitive access path cannot fall back to a table scan and filesort.
+
+For an existing table that uses the original status-only index, replace it:
+
+```sql
+ALTER TABLE jobs
+    DROP INDEX idx_status,
+    ADD INDEX idx_jobs_claim (status, created_at, id);
+```
+
+Check the access plan with production-like data:
+
+```sql
+EXPLAIN
+SELECT id, payload
+FROM jobs FORCE INDEX (idx_jobs_claim)
+WHERE status = 'pending'
+ORDER BY created_at, id
+LIMIT 1
+FOR UPDATE SKIP LOCKED;
+```
+
+The plan should use `idx_jobs_claim`, and its `Extra` column should not contain `Using filesort`. MySQL documents how a [composite index can satisfy `ORDER BY`](https://dev.mysql.com/doc/refman/8.0/en/order-by-optimization.html) when its first column is fixed by the `WHERE` clause. Recheck this plan after MySQL upgrades or schema changes; do not rely on the queue's concurrency behavior if `Using filesort` appears.
 
 Worker process:
 
@@ -77,9 +115,9 @@ START TRANSACTION;
 
 -- Claim the next available job, skipping any locked by other workers
 SELECT id, payload
-FROM jobs
+FROM jobs FORCE INDEX (idx_jobs_claim)
 WHERE status = 'pending'
-ORDER BY created_at
+ORDER BY created_at, id
 LIMIT 1
 FOR UPDATE SKIP LOCKED;
 
@@ -102,9 +140,9 @@ def claim_next_job(conn):
     conn.start_transaction()
 
     cursor.execute("""
-        SELECT id, payload FROM jobs
+        SELECT id, payload FROM jobs FORCE INDEX (idx_jobs_claim)
         WHERE status = 'pending'
-        ORDER BY created_at
+        ORDER BY created_at, id
         LIMIT 1
         FOR UPDATE SKIP LOCKED
     """)
@@ -144,4 +182,4 @@ DELIMITER ;
 
 ## Summary
 
-`SKIP LOCKED` and `NOWAIT` in MySQL 8.0 are essential tools for building concurrent job queues and worker pools. `SKIP LOCKED` enables multiple workers to efficiently pull work items without blocking each other, while `NOWAIT` provides immediate feedback when a row is contended. Together, they eliminate lock wait bottlenecks and enable scalable producer-consumer patterns directly in MySQL.
+`SKIP LOCKED` and `NOWAIT` in MySQL 8.0 are useful tools for building concurrent job queues and worker pools. With a claim access path that matches the filter and order, plus short claim transactions, `SKIP LOCKED` reduces row-lock waits and lets workers claim different jobs concurrently. `NOWAIT` provides immediate feedback when a row is contended. Both clauses complement careful query-plan and transaction design rather than replacing it.

--- a/posts/2026-03-31-mysql-skip-locked-and-nowait-mysql-8/validation-summary.md
+++ b/posts/2026-03-31-mysql-skip-locked-and-nowait-mysql-8/validation-summary.md
@@ -13,6 +13,9 @@ Tutorial
 
 ## Sources Consulted
 - MySQL 8.0 Reference Manual: Locking Reads (SELECT ... FOR UPDATE / FOR SHARE) — https://dev.mysql.com/doc/refman/8.0/en/innodb-locking-reads.html
+- MySQL 8.0 Reference Manual: Locks Set by Different SQL Statements in InnoDB - https://dev.mysql.com/doc/refman/8.0/en/innodb-locks-set.html
+- MySQL 8.0 Reference Manual: ORDER BY Optimization - https://dev.mysql.com/doc/refman/8.0/en/order-by-optimization.html
+- MySQL 8.0 Reference Manual: LIMIT Query Optimization - https://dev.mysql.com/doc/refman/8.0/en/limit-optimization.html
 - MySQL 8.0 Reference Manual: DECLARE ... HANDLER syntax — https://dev.mysql.com/doc/refman/8.0/en/declare-handler.html
 - MySQL 8.0 Reference Manual: Server Error Message Reference (Error 3572) — https://dev.mysql.com/doc/mysql-errors/8.0/en/server-error-reference.html
 - MySQL Connector/Python Developer Guide — https://dev.mysql.com/doc/connector-python/en/
@@ -22,7 +25,11 @@ Tutorial
 
 2. **Overly broad SQLSTATE in error handler**: The original used `DECLARE EXIT HANDLER FOR SQLSTATE 'HY000'`, which is a general SQLSTATE class covering thousands of different MySQL errors. This would catch many unrelated errors beyond NOWAIT lock failures. Fixed by using `DECLARE EXIT HANDLER FOR 3572`, which is the specific MySQL error number for "Statement aborted because lock(s) could not be acquired immediately and NOWAIT is set."
 
+3. **Claim query serialized by filesort**: The schema indexed only `status` while the worker queries ordered by `created_at`. The locking scan feeding that filesort can lock every pending index record, defeating `SKIP LOCKED` concurrency. Fixed by adding `idx_jobs_claim (status, created_at, id)`, forcing that claim index, using `ORDER BY created_at, id` consistently, and documenting how to verify that `EXPLAIN` does not report `Using filesort`.
+
 ## Review Notes
 - The job queue worker SQL pattern correctly places the final `UPDATE ... SET status = 'done'` outside the claim transaction. This is the right approach — the lock is released quickly after claiming, and processing happens without holding the row lock.
 - The Python example correctly uses `mysql.connector` APIs including `cursor(dictionary=True)`, `start_transaction()`, and parameterized queries with `%s` placeholders.
 - The `:claimed_id` and `:target_id` named parameter syntax used in the SQL examples is not native MySQL syntax but is a common pseudocode convention in tutorials. This is acceptable in context.
+- The claim queries use `id` as a deterministic tie-breaker for jobs that share the same `created_at` value.
+- The claim queries force `idx_jobs_claim` because MySQL can otherwise choose a table scan and filesort when `status` has low selectivity, even when the composite index exists.

--- a/posts/2026-03-31-mysql-skip-locked-and-nowait-mysql-8/validation.json
+++ b/posts/2026-03-31-mysql-skip-locked-and-nowait-mysql-8/validation.json
@@ -1,4 +1,4 @@
 {
     "status": "validated",
-    "validatedAt": "2026-04-11"
+    "validatedAt": "2026-08-11"
 }


### PR DESCRIPTION
## Summary

- replace the status-only queue index with a deterministic `(status, created_at, id)` claim index
- force the concurrency-sensitive claim access path so MySQL cannot choose a filesort that locks every pending candidate
- document migration and `EXPLAIN` verification guidance
- refresh the post's technical validation record

## Root cause

The original locking query filtered by `status` but ordered by `created_at`. Its status-only index could not satisfy that order, so MySQL scanned the pending set and used filesort before returning `LIMIT 1`. Because an InnoDB locking read locks scanned index records, the first worker could lock every candidate and a second `SKIP LOCKED` worker could return no job.

## Validation

- `npm run validate` (all 59,135 posts passed)
- `npx tsc --noEmit`
- `git diff --check`
- MySQL 8.0.46 regression: reproduced an empty worker-2 result with the original schema; verified `idx_jobs_claim` with no `Using filesort` and distinct worker claims with the corrected query, including equal timestamps

Fixes OneUptime/oneuptime#3117