### PR TITLE
update inaccurate claim about default subvolume layout

### DIFF
--- a/posts/2026-03-02-ubuntu-server-btrfs-root-filesystem/README.md
+++ b/posts/2026-03-02-ubuntu-server-btrfs-root-filesystem/README.md
@@ -35,11 +35,12 @@ At the storage configuration step:
 3. Create the boot partition (2GB, ext4, mounted at `/boot`) - keep `/boot` as ext4 because GRUB's Btrfs support is limited
 4. Create the root partition using the remaining space, formatted as Btrfs
 
-When formatting the root partition as Btrfs, the installer will set up subvolumes. Ubuntu typically creates:
+When formatting the root partition as Btrfs, subvolumes may or may not be set up depending on the installer.
+One or more ubuntu installers have been known to use this subvolume layout:
 - `@` - mounted at `/`
 - `@home` - mounted at `/home`
 
-This subvolume layout is important because it allows snapshotting `/` without including `/home` in the snapshot (and vice versa).
+This layout is useful because it allows snapshotting `/` without including `/home` in the snapshot (and vice versa).
 
 ## Manual Btrfs Setup
 


### PR DESCRIPTION
I installed ubuntu server 26.04 yesterday using the default .iso and it did not create my any subvolumes. There are plenty of examples of people saying the same thing:

* > The installer cannot configure iSCSI mounts or BTRFS subvolumes.
  https://canonical-subiquity.readthedocs-hosted.com/en/latest/howto/configure-storage.html#limitations-and-workarounds
* > the flat Btrfs layout (without @ and @home subvolumes) is the intentional default behavior of the modern Ubuntu desktop installer (Subiquity) since Ubuntu 24.04 LTS.
  https://askubuntu.com/questions/1566142/ubuntu-26-04-btrfs-missing-subvolumes
* >  I recently learned that the Ubuntu 24.04 installer no longer uses subvolumes when selecting BTRFS as a file system.
  https://www.reddit.com/r/btrfs/comments/1dq04qx/convert_ubuntu_btrfs_installation_into_subvolumes/
* > Why does Ubuntu 18.04 doesn't create multiple BTRFS subvolumes anymore during installation by default?
  https://lists.ubuntu.com/archives/ubuntu-users/2018-September/295356.html