### PR TITLE
Enhance GitLab deployment guide with reverse proxy note

### DIFF
--- a/posts/2026-03-20-deploy-gitlab-portainer/README.md
+++ b/posts/2026-03-20-deploy-gitlab-portainer/README.md
@@ -4,7 +4,8 @@ Author: [nawazdhandala](https://www.github.com/nawazdhandala)
 
 Tags: Portainer, GitLab, Git, CI/CD, Self-Hosted
 
-Description: Learn how to deploy self-hosted GitLab CE via Portainer with persistent storage, SSL configuration, and GitLab Runner integration for CI/CD pipelines.
+Description: 
+Learn how to deploy self-hosted GitLab CE via Portainer with persistent storage, SSL configuration, and GitLab Runner integration for CI/CD pipelines. Note: This guide is designed for environments utilizing an external reverse proxy. It assumes a service like NGINX, Apache, or Traefik is positioned at the edge of your network to intercept incoming web traffic, manage SSL certificates, and route connections to this isolated GitLab stack.
 
 ## GitLab via Portainer Stack
 
@@ -40,7 +41,7 @@ services:
         sidekiq['max_concurrency'] = 10
         gitlab_rails['db_pool'] = 10
     ports:
-      - "8929:80"       # HTTP (behind reverse proxy)
+      - "8929:80"       # HTTP (behind reverse proxy)                   
       - "2222:22"       # SSH for Git
     volumes:
       - gitlab_config:/etc/gitlab


### PR DESCRIPTION
Added a note about external reverse proxy requirements for the GitLab deployment guide.

If you like this small addition I can go further by adding some additional supporting comments. 




i really like the straightforward guide you've written though, I just personally thought that adding some supporting context would make your comments further down, specifically the lines where you define the ports would make more sense with the understanding that this deployment depends on an external reverse-proxy service of some kind. In any case let me know what you think and thank you for your time, consideration, and guide!.   